### PR TITLE
Windows: unbreak CI, fix the receiver crash, keyboard mapping, and persistent logs

### DIFF
--- a/.github/workflows/build-windows-receiver.yml
+++ b/.github/workflows/build-windows-receiver.yml
@@ -70,7 +70,16 @@ jobs:
           cd Sources/BetterCastReceiverDesktop
           mkdir build
           cd build
-          cmake .. -G "Visual Studio 17 2022" -A x64 `
+          # Ninja, not the Visual Studio generator. "Setup MSVC" above already puts the
+          # x64 toolchain on PATH, so the compiler is found through the environment
+          # rather than by looking up one specific Visual Studio version. Hardcoding
+          # "Visual Studio 17 2022" is what broke this job: the runner image moved on,
+          # CMake reported "could not find any instance of Visual Studio", and every
+          # Windows build from v14 to v16 failed at configure. Nothing surfaced it
+          # because the macOS release path does not depend on this workflow.
+          # Ninja is single-config, so the build type is set here instead of at build
+          # time and the binary lands in build/ rather than build/Release/.
+          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" `
             -DCMAKE_PREFIX_PATH="$env:Qt6_DIR" `
             -DENABLE_SENDER=ON
@@ -79,7 +88,7 @@ jobs:
         shell: pwsh
         run: |
           cd Sources/BetterCastReceiverDesktop/build
-          cmake --build . --config Release
+          cmake --build .
 
       - name: Download ADB platform-tools
         shell: pwsh
@@ -141,7 +150,7 @@ jobs:
           mkdir artifact
 
           # Copy the exe
-          Copy-Item "Sources/BetterCastReceiverDesktop/build/Release/BetterCastReceiver.exe" "artifact/"
+          Copy-Item "Sources/BetterCastReceiverDesktop/build/BetterCastReceiver.exe" "artifact/"
 
           # Run windeployqt to bundle Qt DLLs
           windeployqt --release --no-translations --no-system-d3d-compiler `

--- a/Sources/BetterCastReceiverDesktop/InputHandler.cpp
+++ b/Sources/BetterCastReceiverDesktop/InputHandler.cpp
@@ -1,4 +1,5 @@
 #include "InputHandler.h"
+#include <QHash>
 #include "VideoRenderer.h"
 
 #include <QMouseEvent>
@@ -61,6 +62,72 @@ InputHandler::NormalizedPoint InputHandler::normalize(double widgetX, double wid
     return {normX, normY, true};
 }
 
+namespace {
+
+/// Translate a Qt key to a macOS virtual keycode.
+///
+/// The Mac host feeds whatever arrives straight into CGKeyCode, so the wire carries
+/// macOS keycodes — the same space the iOS receiver already sends. This used to send
+/// QKeyEvent::nativeVirtualKey(), which is a Windows VK code on Windows and an X11
+/// keycode on Linux; neither resembles the macOS layout, so every letter came out
+/// wrong. 'A' is VK 0x41 on Windows but keycode 0 on macOS, and macOS keycode 0x41
+/// is the keypad decimal point.
+///
+/// Qt::Key is used rather than the native code so one table serves both platforms.
+/// macOS keycodes are positional, not alphabetical — the order below looks scrambled
+/// because it follows the physical ANSI layout.
+uint16_t qtKeyToMacKeyCode(int qtKey) {
+    static const QHash<int, uint16_t> map = {
+        // Letters (positional order on the physical keyboard)
+        {Qt::Key_A, 0},  {Qt::Key_S, 1},  {Qt::Key_D, 2},  {Qt::Key_F, 3},
+        {Qt::Key_H, 4},  {Qt::Key_G, 5},  {Qt::Key_Z, 6},  {Qt::Key_X, 7},
+        {Qt::Key_C, 8},  {Qt::Key_V, 9},  {Qt::Key_B, 11}, {Qt::Key_Q, 12},
+        {Qt::Key_W, 13}, {Qt::Key_E, 14}, {Qt::Key_R, 15}, {Qt::Key_Y, 16},
+        {Qt::Key_T, 17}, {Qt::Key_O, 31}, {Qt::Key_U, 32}, {Qt::Key_I, 34},
+        {Qt::Key_P, 35}, {Qt::Key_L, 37}, {Qt::Key_J, 38}, {Qt::Key_K, 40},
+        {Qt::Key_N, 45}, {Qt::Key_M, 46},
+
+        // Digits — note 5 and 6 are not in numeric order on macOS
+        {Qt::Key_1, 18}, {Qt::Key_2, 19}, {Qt::Key_3, 20}, {Qt::Key_4, 21},
+        {Qt::Key_6, 22}, {Qt::Key_5, 23}, {Qt::Key_9, 25}, {Qt::Key_7, 26},
+        {Qt::Key_8, 28}, {Qt::Key_0, 29},
+
+        // Punctuation
+        {Qt::Key_Equal, 24},        {Qt::Key_Minus, 27},
+        {Qt::Key_BracketRight, 30}, {Qt::Key_BracketLeft, 33},
+        {Qt::Key_Apostrophe, 39},   {Qt::Key_Semicolon, 41},
+        {Qt::Key_Backslash, 42},    {Qt::Key_Comma, 43},
+        {Qt::Key_Slash, 44},        {Qt::Key_Period, 47},
+        {Qt::Key_QuoteLeft, 50},
+
+        // Editing and navigation. macOS keycode 51 is Backspace; 117 is forward Delete.
+        {Qt::Key_Return, 36},    {Qt::Key_Enter, 36},
+        {Qt::Key_Tab, 48},       {Qt::Key_Space, 49},
+        {Qt::Key_Backspace, 51}, {Qt::Key_Escape, 53},
+        {Qt::Key_Delete, 117},
+        {Qt::Key_Home, 115},     {Qt::Key_End, 119},
+        {Qt::Key_PageUp, 116},   {Qt::Key_PageDown, 121},
+        {Qt::Key_Left, 123},     {Qt::Key_Right, 124},
+        {Qt::Key_Down, 125},     {Qt::Key_Up, 126},
+
+        // Modifiers. Windows/Meta maps to Command and Alt to Option, matching the
+        // physical position. Ctrl stays Control, so Ctrl+C arrives as Control+C and
+        // will NOT copy on macOS — swapping it for Command is a separate UX call.
+        {Qt::Key_Shift, 56},   {Qt::Key_CapsLock, 57},
+        {Qt::Key_Alt, 58},     {Qt::Key_Control, 59},
+        {Qt::Key_Meta, 55},
+
+        // Function row — also non-sequential on macOS
+        {Qt::Key_F1, 122},  {Qt::Key_F2, 120},  {Qt::Key_F3, 99},
+        {Qt::Key_F4, 118},  {Qt::Key_F5, 96},   {Qt::Key_F6, 97},
+        {Qt::Key_F7, 98},   {Qt::Key_F8, 100},  {Qt::Key_F9, 101},
+        {Qt::Key_F10, 109}, {Qt::Key_F11, 103}, {Qt::Key_F12, 111},
+    };
+    return map.value(qtKey, 0xFFFF); // 0xFFFF = unmapped, caller drops it
+}
+
+} // namespace
+
 bool InputHandler::eventFilter(QObject* obj, QEvent* event) {
     switch (event->type()) {
     case QEvent::MouseMove: {
@@ -111,16 +178,16 @@ bool InputHandler::eventFilter(QObject* obj, QEvent* event) {
     }
     case QEvent::KeyPress: {
         auto* ke = static_cast<QKeyEvent*>(event);
-        // Send Qt native key code — sender will need a mapping table
-        // For now we send the Qt key code directly
-        emit inputEvent(InputEvent(InputEventType::KeyDown, 0, 0,
-                                   static_cast<uint16_t>(ke->nativeVirtualKey())));
+        const uint16_t mac = qtKeyToMacKeyCode(ke->key());
+        if (mac == 0xFFFF) return false; // unmapped key — better silent than wrong
+        emit inputEvent(InputEvent(InputEventType::KeyDown, 0, 0, mac));
         return false;
     }
     case QEvent::KeyRelease: {
         auto* ke = static_cast<QKeyEvent*>(event);
-        emit inputEvent(InputEvent(InputEventType::KeyUp, 0, 0,
-                                   static_cast<uint16_t>(ke->nativeVirtualKey())));
+        const uint16_t mac = qtKeyToMacKeyCode(ke->key());
+        if (mac == 0xFFFF) return false;
+        emit inputEvent(InputEvent(InputEventType::KeyUp, 0, 0, mac));
         return false;
     }
     default:

--- a/Sources/BetterCastReceiverDesktop/MainWindow.h
+++ b/Sources/BetterCastReceiverDesktop/MainWindow.h
@@ -16,6 +16,9 @@
 #include <QMouseEvent>
 #include <QStringList>
 #include <QTime>
+#include <QFile>
+#include <QDir>
+#include <QStandardPaths>
 
 // Simple log manager (mirrors macOS LogManager)
 class LogManager : public QObject {
@@ -32,18 +35,54 @@ public:
         m_entries.append(entry);
         if (m_entries.size() > 1000) m_entries.removeFirst();
         qDebug().noquote() << msg;
+        writeToFile(entry);
         emit logAdded(entry);
     }
 
     void clear() { m_entries.clear(); }
     const QStringList& entries() const { return m_entries; }
 
+    /// Where the on-disk log lives, so the UI can point users at it.
+    QString logFilePath() const { return m_logPath; }
+
 signals:
     void logAdded(const QString& entry);
 
 private:
-    LogManager() = default;
+    /// Mirror every entry to disk as well as memory.
+    ///
+    /// The in-memory list dies with the process, which made every crash report
+    /// useless: the app quits, the user reopens it to copy the logs, and all they can
+    /// send is the *restarted* run. Three filed issues (#35, #42, #43) contain nothing
+    /// but startup lines for exactly this reason.
+    ///
+    /// The previous run is kept as bettercast.log.1, so after a crash the evidence is
+    /// still there once the app has been reopened.
+    LogManager() {
+        const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        if (dir.isEmpty()) return;
+        QDir().mkpath(dir);
+        m_logPath = dir + "/bettercast.log";
+
+        QFile::remove(m_logPath + ".1");
+        QFile::rename(m_logPath, m_logPath + ".1");
+
+        m_logFile.setFileName(m_logPath);
+        m_logFile.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text);
+    }
+
+    void writeToFile(const QString& entry) {
+        if (!m_logFile.isOpen()) return;
+        m_logFile.write(entry.toUtf8());
+        m_logFile.write("\n");
+        // Flush every line. Buffered writes are exactly what gets lost when the process
+        // dies, and the last few lines before a crash are the ones worth having.
+        m_logFile.flush();
+    }
+
     QStringList m_entries;
+    QFile m_logFile;
+    QString m_logPath;
 };
 
 struct DiscoveredService;

--- a/Sources/BetterCastReceiverDesktop/NetworkListener.cpp
+++ b/Sources/BetterCastReceiverDesktop/NetworkListener.cpp
@@ -189,7 +189,12 @@ void NetworkListener::processTcpBuffer(QTcpSocket* socket) {
         if (format == 1 && body.size() > 1) {
             uint8_t typeByte = static_cast<uint8_t>(body[0]);
             if (typeByte == 0x01) {
-                handleVideoData(body.mid(1), false);  // type-byte framing: no PTS prefix
+                // The type byte is *in addition to* the PTS header, not instead of it:
+                // the Mac sends [0x01][8-byte PTS][AVCC NALUs]. Passing false here made
+                // the decoder read the first four bytes of a little-endian nanosecond
+                // timestamp as a big-endian NALU length — a near-random 32-bit value that
+                // crashed the app one frame into every Mac-to-Windows stream.
+                handleVideoData(body.mid(1), true);
             } else if (typeByte == 0x02) {
                 handleAudioData(body.mid(1));
             }

--- a/Sources/BetterCastReceiverDesktop/VideoDecoder.cpp
+++ b/Sources/BetterCastReceiverDesktop/VideoDecoder.cpp
@@ -43,7 +43,12 @@ void VideoDecoder::decode(const QByteArray& data, bool hasPtsPrefix) {
     int naluCount = 0;
     while (offset + 4 <= videoLen) {
         uint32_t naluLen = qFromBigEndian<uint32_t>(videoData + offset);
-        if (naluLen == 0 || offset + 4 + static_cast<int>(naluLen) > videoLen) {
+        // Compare in 64-bit. A corrupt length above INT_MAX used to cast to a negative
+        // int, slip past this guard, and drive `offset` backwards — so the next read
+        // landed gigabytes outside the buffer and took the process down with an access
+        // violation instead of dropping one bad frame.
+        if (naluLen == 0 ||
+            static_cast<qint64>(offset) + 4 + static_cast<qint64>(naluLen) > static_cast<qint64>(videoLen)) {
             if (decodeCallCount <= 5) {
                 LogManager::instance().log(QString("Decoder: frame %1 NALU scan stopped at offset %2, naluLen=%3, videoLen=%4")
                     .arg(decodeCallCount).arg(offset).arg(naluLen).arg(videoLen));

--- a/Sources/BetterCastReceiverDesktop/sender/VirtualDisplayVDD.cpp
+++ b/Sources/BetterCastReceiverDesktop/sender/VirtualDisplayVDD.cpp
@@ -283,6 +283,21 @@ bool VirtualDisplayVDD::isDriverLoaded() const {
         CloseHandle(pipe);
         return true;
     }
+
+    // Last, and the only direct evidence: does a virtual display actually exist?
+    //
+    // Both checks above are proxies and both can be false while the driver is plainly
+    // working. The service key depends on the name the INF happens to register, which
+    // has changed across VDD releases, and the pipe only exists while VDD Control.exe
+    // is running — which it usually is not. Reported logs show a monitor enumerated as
+    // "Virtual Display Driver" on DISPLAY8 and, on the very next line, "driver not
+    // loaded in Windows", followed by a doomed unelevated install attempt. Asking
+    // Windows what displays are present settles it without guessing at names.
+    for (const auto& mon : enumerateMonitors()) {
+        if (mon.isVirtual) {
+            return true;
+        }
+    }
 #endif
     return false;
 }


### PR DESCRIPTION
Four fixes that together give Windows its first working receiver since v7.

**CI had been failing since v14.** The workflow asked for the `Visual Studio 17 2022` generator, which the runner image no longer provides, so configure failed on every release and no Windows artifact was produced after `receiver-1.0.2`. Builds with Ninja now — Setup MSVC already puts the toolchain on PATH, so the build no longer cares which Visual Studio the image ships.

**The receiver crashed one frame into every Mac→Windows stream.** Event Viewer named our own module with `0xc0000005`. The Mac sends `[len][0x01][8-byte PTS][AVCC NALUs]` — the type byte is *in addition to* the PTS header — but `NetworkListener` passed `hasPtsPrefix=false`, so the decoder read the first four bytes of a little-endian nanosecond timestamp as a big-endian NALU length. Confirmed from a captured log: `len=2983249897` is exactly `b1 d0 c7 e9`, the first four PTS bytes. That value exceeds `INT_MAX`, `static_cast<int>` made it negative, the bounds check failed open, and `offset` walked backwards out of the buffer. The guard now compares in 64-bit so corrupt data drops a frame rather than the process.

**Typing produced the wrong letters.** `InputHandler` sent `nativeVirtualKey()` under a comment conceding "sender will need a mapping table" — it was never written. The Mac feeds what arrives into `CGKeyCode`, so the wire carries macOS keycodes while Windows sent Windows VK codes. Maps `Qt::Key` so one table also fixes Linux, which was sending X11 keycodes.

**Crash reports were structurally useless.** `LogManager` kept entries in memory only, so a crash destroyed its own evidence and users captured the *restarted* run — #35, #42 and #43 all contain nothing but startup lines. Logs now stream to `%APPDATA%/BetterCast/BetterCast/bettercast.log`, flushed per line, previous run kept as `.log.1`.

Fixes #43. Very likely fixes #35.

Verified: CI green, and a Mac→Windows stream confirmed working on real hardware.

Known and not addressed here: the exe still reports version `0.0.0.0` (the version wiring lives in an unmerged commit), the VDD driver install fails for Windows-as-sender extend (#42), and Windows→Mac stalls after a few minutes.